### PR TITLE
new docker image based on Windows 2019 server core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM microsoft/windowsservercore
-ENV ClamVersion 0.99.2
+FROM mcr.microsoft.com/windows/servercore:1903
+ENV ClamVersion 0.102.2
+ENV ClamAVDestinationPath C:/Program Files/ClamAV-x64
 
 WORKDIR c:/
 RUN mkdir logs
 RUN mkdir db
 
-RUN powershell -Command "wget -Uri https://www.clamav.net/downloads/production/clamav-%ClamVersion%-x64.msi -OutFile clamav.msi -UseBasicParsing"
-RUN msiexec.exe /q /i clamav.msi
-RUN powershell -Command Remove-Item -Path c:/clamav.msi
+RUN powershell -Command "wget -Uri https://www.clamav.net/downloads/production/clamav-%ClamVersion%-win-x64-portable.zip -OutFile clamav-win-x64-portable.zip -UseBasicParsing"
+RUN powershell -Command Expand-Archive -Path c:/clamav-win-x64-portable.zip -DestinationPath 'C:/Program Files/ClamAV-x64'
+RUN powershell -Command Remove-Item -Path c:/clamav-win-x64-portable.zip
 
 WORKDIR C:/Program Files/ClamAV-x64
 

--- a/clamd.conf
+++ b/clamd.conf
@@ -1,4 +1,3 @@
-TCPAddr 127.0.0.1
 TCPSocket 3310
 MaxThreads 2
 LogTime true

--- a/freshclam.conf
+++ b/freshclam.conf
@@ -1,7 +1,9 @@
-DatabaseDirectory "C:/db/"
+DatabaseDirectory C:\db
 DatabaseMirror database.clamav.net
 MaxAttempts 3
 NotifyClamd C:/Program Files/ClamAV-x64/clamd.conf
 LogFileMaxSize 20480000
 LogTime true
 UpdateLogFile C:/logs/freshclam.log
+LogVerbose yes
+Checks 12

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ The docker image is built on Windows 2019 (Build 1903). It is forked from https:
 ## Usage
 
 ```
-docker run -d -p 3310:3310 williamwlchen/clamav-windows
+docker run -d -p 3310:3310 grofit/clamav-windows
 ```
 
 ## Environment Vars

--- a/readme.md
+++ b/readme.md
@@ -1,15 +1,17 @@
 # docker-clamav-windows
 
-A windows (windowsservercore) docker image that will run ClamAV (clamd) and expose port 3310.
+A windows (windows/servercore) docker image that will run ClamAV (clamd) and expose port 3310.
 
 It will run freshclam before it starts hosting clamd, so should get latest database.
+
+The docker image is built on Windows 2019 (Build 1903). It is forked from https://github.com/grofit/docker-clamav-windows
 
 ## Usage
 
 ```
-docker run -d -p 3310:3310 grofit/clamav-windows
+docker run -d -p 3310:3310 williamwlchen/clamav-windows
 ```
-    
+
 ## Environment Vars
 
-**ClamVersion** - Defaults to 0.99.2
+**ClamVersion** - Defaults to 0.102.2


### PR DESCRIPTION
* update docker base windows image to Windows 2019.
* update ClamAV to version 0.102.2
